### PR TITLE
Utilize es6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-    - "0.10"
     - '4.2'
     - '5.1'
 script:

--- a/bin/run-server.js
+++ b/bin/run-server.js
@@ -1,29 +1,30 @@
 #!/usr/bin/env node
 
-var
-	Numbat = require('../index'),
-	bole   = require('bole'),
-	path   = require('path');
+"use strict";
 
-var config = require(path.resolve(process.argv[2]));
+const Numbat = require('../index'),
+      bole   = require('bole'),
+      path   = require('path');
 
-var opts = config.logging || {};
-var outputs = [];
-var level = opts.level || 'info';
+const config = require(path.resolve(process.argv[2]));
+
+const opts = config.logging || {};
+const outputs = [];
+const level = opts.level || 'info';
 
 if (!opts.silent)
 {
-	if (process.env.NODE_ENV === 'dev')
-	{
-		var prettystream = require('bistre')({time: true});
-		prettystream.pipe(process.stdout);
-		outputs.push({ level:  'debug', stream: prettystream });
-	}
-	else
-		outputs.push({level: level, stream: process.stdout});
+    if (process.env.NODE_ENV === 'dev')
+    {
+        let prettystream = require('bistre')({time: true});
+        prettystream.pipe(process.stdout);
+        outputs.push({ level:  'debug', stream: prettystream });
+    }
+    else
+        outputs.push({level: level, stream: process.stdout});
 }
 
 bole.output(outputs);
 
-var server = new Numbat(config);
+const server = new Numbat(config);
 server.listen();

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-var Numbat            = require('./lib/collector');
+"use strict";
+
+const Numbat          = require('./lib/collector');
 Numbat.InfluxOutput   = require('./lib/output-influx');
 Numbat.LogOutput      = require('./lib/output-logfile');
 Numbat.AnalyzerOutput = require('./lib/output-analyzer');

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -1,4 +1,6 @@
-var
+"use strict";
+
+const
 	_               = require('lodash'),
 	assert          = require('assert'),
 	bole            = require('bole'),
@@ -13,7 +15,7 @@ var
 	http            = require('http')
 	;
 
-var Collector = module.exports = function Collector(opts)
+const Collector = module.exports = function Collector(opts)
 {
 	assert(opts && _.isObject(opts), 'you must pass an options object');
 	assert(opts.listen && _.isObject(opts.listen), 'you must pass a host/port or path object in `listen`');
@@ -31,10 +33,10 @@ var Collector = module.exports = function Collector(opts)
 
 	this.sink = new Sink(opts.outputs);
 	this.sink.setMaxListeners(100);
-	this.sink.on('error', function(err)
+	this.sink.on('error', (err) =>
 	{
 		this.log.warn(err);
-	}.bind(this));
+	});
 	this.streams = [];
 };
 util.inherits(Collector, events.EventEmitter);
@@ -45,12 +47,12 @@ Collector.prototype.incoming = null; // the server listening for metrics
 
 Collector.prototype.listen = function listen(cb)
 {
-	var opts = this.options.listen;
+	let opts = this.options.listen;
 
 	if (opts.udp)
 		return this.bind();
 
-	function report(item)
+	let report = (item) =>
 	{
 		this.log.info('metrics collector now listening @ ' + item);
 		if (cb) cb();
@@ -61,10 +63,10 @@ Collector.prototype.listen = function listen(cb)
 
 	if (opts.path)
 	{
-		fs.unlink(opts.path, function()
+		fs.unlink(opts.path, () =>
 		{
 			this.incoming.listen(opts.path, report.bind(this, opts.path));
-		}.bind(this));
+		});
 	}
 	else
 		this.incoming.listen(opts.port, opts.host, report.bind(this, opts.port));
@@ -75,7 +77,7 @@ Collector.prototype.listen = function listen(cb)
 Collector.prototype.destroy = function destroy(callback)
 {
 	this.log.info('destroy called; closing servers');
-	this.incoming.close(function()
+	this.incoming.close(() =>
 	{
 		// TODO
 		callback();
@@ -84,17 +86,16 @@ Collector.prototype.destroy = function destroy(callback)
 
 Collector.prototype.onConnection = function onConnection(socket)
 {
-	var self = this;
-	var address = socket.address();
+	let address = socket.address();
 	this.log.info('new tcp connection', { socket:  address });
 
-	var jsonStream = new JSONStream();
+	let jsonStream = new JSONStream();
 	socket.pipe(jsonStream, { end: false }).pipe(this.sink, { end: false });
 
-	socket.on('end', function onEndSocket()
+	socket.on('end', () =>
 	{
-		jsonStream.unpipe(self.sink);
-		self.log.info('tcp connection ending', { socket: address });
+		jsonStream.unpipe(this.sink);
+		this.log.info('tcp connection ending', { socket: address });
 	});
 
 	this.emit('connection', socket);
@@ -104,7 +105,7 @@ Collector.prototype.onConnection = function onConnection(socket)
 
 Collector.prototype.bind = function bind()
 {
-	var opts = this.options.listen;
+	let opts = this.options.listen;
 	this.incoming.bind(opts.port, opts.host);
 };
 
@@ -112,18 +113,18 @@ Collector.prototype.createUDPListener = function()
 {
 	this.incoming = dgram.createSocket('udp4', this.onUDPPacket.bind(this));
 
-	this.incoming.on('error', function(err)
+	this.incoming.on('error', (err) =>
 	{
 		this.log.error('listener error', err);
 		this.incoming.close();
-	}.bind(this));
+	});
 
-	this.incoming.on('listening', function()
+	this.incoming.on('listening', () =>
 	{
-		var addy = this.incoming.address();
+		let addy = this.incoming.address();
 		this.log.info('now listening for data at ' + addy.address + ':' + addy.port);
 		this.emit('ready');
-	}.bind(this));
+	});
 };
 
 Collector.prototype.onUDPPacket = function onUDPPacket(packet, rinfo)
@@ -137,34 +138,33 @@ Collector.prototype.onUDPPacket = function onUDPPacket(packet, rinfo)
 
 Collector.prototype.createWebsocketListener = function createWebsocketListener()
 {
-	var self = this;
 	this.incoming = http.createServer();
-	var wss = new WebSocketServer({
+	let wss = new WebSocketServer({
 		server : this.incoming,
-		path : self.options.listen.pathname || '/',
+		path : this.options.listen.pathname || '/',
 		disableHixie : true,
-		verifyClient : function verifyClient(info, cb)
+		verifyClient : (info, cb) =>
 		{
-			if (_.isFunction(self.options.listen.verifyClient))
-				return self.options.listen.verifyClient(info, cb);
+			if (_.isFunction(this.options.listen.verifyClient))
+				return this.options.listen.verifyClient(info, cb);
 			cb(true);
 		}
 	});
 
-	wss.on('connection', function wsConnection(ws)
+	wss.on('connection', (ws) =>
 	{
-		self.log.info('new websocket connection', ws._socket.remoteAddress);
+		this.log.info('new websocket connection', ws._socket.remoteAddress);
 
 		// send ping/pong messages to keep connection alive
 		// in case of network issues like loadbalancers
 		// terminating long lived connections etc
-		var pingThreshold = self.options.listen.keepAliveThreshold || 2;
-		var pingFrequency = self.options.listen.keepAliveFrequency || 30 * 1000;
+		let pingThreshold = this.options.listen.keepAliveThreshold || 2;
+		let pingFrequency = this.options.listen.keepAliveFrequency || 30 * 1000;
 
 		ws.pingSent = 0;
-		ws.pingInterval = setInterval(function pingInterval()
+		ws.pingInterval = setInterval(() =>
 		{
-			self.log.debug('websocket sent ping', ws._socket.remoteAddress);
+			this.log.debug('websocket sent ping', ws._socket.remoteAddress);
 			if (ws.readyState !== 1)
 				return;
 			if (ws.pingSent >= pingThreshold)
@@ -173,32 +173,32 @@ Collector.prototype.createWebsocketListener = function createWebsocketListener()
 			ws.pingSent++;
 		}, pingFrequency);
 
-		ws.on('pong', function wsPong()
+		ws.on('pong', () =>
 		{
-			self.log.debug('websocket got pong', ws._socket.remoteAddress);
+			this.log.debug('websocket got pong', ws._socket.remoteAddress);
 			ws.pingSent = 0;
 		});
 
-		ws.on('message', function wsIncoming(message)
+		ws.on('message', (message) =>
 		{
-			self.log.debug('websocket message', ws._socket.remoteAddress);
-			self.sink.write(JSON.parse(message));
+			this.log.debug('websocket message', ws._socket.remoteAddress);
+			this.sink.write(JSON.parse(message));
 		});
 
-		ws.on('close', function wsClose()
+		ws.on('close', () =>
 		{
 			clearInterval(ws.pingInterval);
-			self.log.info('websocket connection ending', ws._socket.remoteAddress);
+			this.log.info('websocket connection ending', ws._socket.remoteAddress);
 		});
 
-		ws.on('error', function wsError(error)
+		ws.on('error', (error) =>
 		{
-			self.log.warn(error);
+			this.log.warn(error);
 		});
 
 	});
 
-	wss.on('error', function wssError(error)
+	wss.on('error', (error) =>
 	{
 		this.log.error('listener error', error);
 	});

--- a/lib/output-analyzer.js
+++ b/lib/output-analyzer.js
@@ -1,4 +1,6 @@
-var
+"use strict";
+
+const
 	_      = require('lodash'),
 	assert = require('assert'),
 	net    = require('net'),
@@ -6,7 +8,7 @@ var
 	util   = require('util')
 	;
 
-var AnalyzerOutput = module.exports = function AnalyzerOutput(opts)
+const AnalyzerOutput = module.exports = function AnalyzerOutput(opts)
 {
 	assert(opts && _.isObject(opts), 'you must pass an options object');
 	assert(opts.host && _.isString(opts.host), 'you must pass a `host` option');

--- a/lib/output-graphite.js
+++ b/lib/output-graphite.js
@@ -1,4 +1,6 @@
-var
+"use strict";
+
+const
 	_      = require('lodash'),
 	assert = require('assert'),
 	bole   = require('bole'),
@@ -7,7 +9,7 @@ var
 	util   = require('util')
 ;
 
-var GraphiteUDP = module.exports = function GraphiteUDP(opts)
+const GraphiteUDP = module.exports = function GraphiteUDP(opts)
 {
 	assert(opts && _.isObject(opts), 'you must pass an options object');
 	assert(opts.host && _.isString(opts.host), 'you must pass a hostname in the `host` option');
@@ -37,14 +39,13 @@ GraphiteUDP.prototype.onError = function onError(err)
 
 GraphiteUDP.prototype.writeBatch = function writeBatch()
 {
-	var self = this;
-	var data = new Buffer(this.batch.join('\n'));
-	this.socket.send(data, 0, data.length, this.options.port, this.options.host, function(err, written)
+	let data = new Buffer(this.batch.join('\n'));
+	this.socket.send(data, 0, data.length, this.options.port, this.options.host, (err, written) =>
 	{
 		if (err)
 		{
-			self.log.error('problem writing to graphite');
-			self.log.error(err);
+			this.log.error('problem writing to graphite');
+			this.log.error(err);
 		}
 		// TODO consider retrying and stuff
 	});

--- a/lib/output-influx.js
+++ b/lib/output-influx.js
@@ -1,4 +1,6 @@
-var
+"use strict";
+
+const
 	_      = require('lodash'),
 	assert = require('assert'),
 	bole   = require('bole'),
@@ -7,7 +9,7 @@ var
 	util   = require('util')
 ;
 
-var InfluxOutput = module.exports = function InfluxOutput(opts)
+const InfluxOutput = module.exports = function InfluxOutput(opts)
 {
 	assert(opts && _.isObject(opts), 'you must pass an options object');
 	assert(opts.hosts && _.isArray(opts.hosts), 'you must pass an array in the `hosts` option');
@@ -33,38 +35,37 @@ InfluxOutput.prototype.THROTTLE  = 300000; // 5 minutes
 InfluxOutput.prototype.toString = function toString()
 {
 	return '[ InfluxDB ' + this.options.database + ' @ ' +
-		_.map(this.options.hosts, function(h) { return h.host; }).join(', ') +
+		_.map(this.options.hosts, (h) => { return h.host; }).join(', ') +
 		' ]';
 };
 
 InfluxOutput.prototype._write = function _write(event, encoding, callback)
 {
-	var point = _.pick(event, function(v) { return !_.isObject(v) && !_.isArray(v); });
+	let point = _.pick(event, (v) => { return !_.isObject(v) && !_.isArray(v); });
 	if (event.time)
 		point.time = event.time;
 	if (point.time && typeof point.time !== 'object') point.time = new Date(point.time);
 
-	var self = this;
-	self.client.writePoint(event.name, point, function(err)
+	this.client.writePoint(event.name, point, (err) =>
 	{
 		if (err)
 		{
 			// throttle error reporting
-			if (self.lasterror + self.THROTTLE < Date.now())
+			if (this.lasterror + this.THROTTLE < Date.now())
 			{
-				self.lasterror = Date.now();
-				if (self.errcount > 0)
-					self.log.error(self.errcount + ' error(s) writing points to influx suppressed');
+				this.lasterror = Date.now();
+				if (this.errcount > 0)
+					this.log.error(this.errcount + ' error(s) writing points to influx suppressed');
 				else
 				{
-					self.log.error('failure writing a point to influx:');
-					self.log.error(event.name, point);
-					self.log.error(err);
+					this.log.error('failure writing a point to influx:');
+					this.log.error(event.name, point);
+					this.log.error(err);
 				}
-				self.errcount = 0;
+				this.errcount = 0;
 			}
 			else
-				self.errcount++;
+				this.errcount++;
 		}
 	});
 

--- a/lib/output-logfile.js
+++ b/lib/output-logfile.js
@@ -1,4 +1,6 @@
-var
+"use strict";
+
+const
 	_      = require('lodash'),
 	assert = require('assert'),
 	bole   = require('bole'),
@@ -7,7 +9,7 @@ var
 	util   = require('util')
 ;
 
-var LogOutput = module.exports = function LogOutput(opts)
+const LogOutput = module.exports = function LogOutput(opts)
 {
 	assert(opts && _.isObject(opts), 'you must pass an options object');
 	assert(opts.name && _.isString(opts.name), 'you must pass a `name` option');
@@ -20,7 +22,7 @@ var LogOutput = module.exports = function LogOutput(opts)
 	{
 		bole.output({
 			level: 'info',
-			stream: fs.createWriteStream(opts.path, { flags: 'a', encoding: 'utf8', mode: 0666 })
+			stream: fs.createWriteStream(opts.path, { flags: 'a', encoding: 'utf8', mode: 0o644 })
 		});
 	}
 	this.client = bole(opts.name);

--- a/lib/output-prettylog.js
+++ b/lib/output-prettylog.js
@@ -1,11 +1,13 @@
-var
+"use strict";
+
+const
 	_      = require('lodash'),
 	bole   = require('bole'),
 	stream = require('stream'),
 	util   = require('util')
 ;
 
-var PrettyLog = module.exports = function PrettyLog(opts)
+const PrettyLog = module.exports = function PrettyLog(opts)
 {
 	stream.Writable.call(this, { objectMode: true });
 
@@ -14,7 +16,7 @@ var PrettyLog = module.exports = function PrettyLog(opts)
 	else if (opts && _.isObject(opts) && opts.name)
 		this.name = opts.name;
 
-	var prettystream = require('bistre')({time: true});
+	let prettystream = require('bistre')({time: true});
 
 	if (opts && opts.pipe) prettystream.pipe(process.stdout);
 	bole.output({ level: 'info', stream: prettystream });

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -1,6 +1,8 @@
+"use strict";
+
 // Like a heat sink but for metrics
 
-var
+const
 	_         = require('lodash'),
 	Analyzer  = require('./output-analyzer'),
 	assert    = require('assert'),
@@ -14,7 +16,7 @@ var
 	util      = require('util')
 ;
 
-var Sink = module.exports = function Sink(outputs)
+const Sink = module.exports = function Sink(outputs)
 {
 	assert(outputs && _.isArray(outputs), 'you must pass an array of outputs');
 
@@ -23,7 +25,7 @@ var Sink = module.exports = function Sink(outputs)
 	this.log = bole('sink');
 	var self = this;
 
-	this.clients = _.map(outputs, function(opts)
+	this.clients = _.map(outputs, (opts) =>
 	{
 		switch (opts.type)
 		{
@@ -49,14 +51,14 @@ var Sink = module.exports = function Sink(outputs)
 			return new PrettyLog(opts);
 
 		default:
-			self.log.warn(opts, 'skipping output; unknown type ' + opts.type);
+			this.log.warn(opts, 'skipping output; unknown type ' + opts.type);
 		}
 	});
 
-	_.each(this.clients, function(c)
+	_.each(this.clients, (c) =>
 	{
 		if (c) this.pipe(c);
-	}.bind(this));
+	});
 };
 util.inherits(Sink, stream.PassThrough);
 


### PR DESCRIPTION
This utilize some es6 features.

* "strict mode" are introduced (needed for es6)
* use `const` and `let` instead of `var` where apropiate.
* use arrow functions

My main motivation for this is that arrow functions makes it possible to remove a lot of the `.bind` used. We are also able to remove all `var self = this;`trickery.

The downside of this is that support for node.js 0.10.x must be dropped. Though; I don't think that is much of a downside but it makes this a breaking feature. travis config is updated to omit 0.10.x.