### PR TITLE
support lodash 4.3.0

### DIFF
--- a/lib/output-influx.js
+++ b/lib/output-influx.js
@@ -39,7 +39,7 @@ InfluxOutput.prototype.toString = function toString()
 
 InfluxOutput.prototype._write = function _write(event, encoding, callback)
 {
-	var point = _.pick(event, ['name', 'value', 'time']);
+	var point = _.pickBy(event, function(v) { return !_.isObject(v) && !_.isArray(v); });
 	if (event.time)
 		point.time = event.time;
 	if (point.time && typeof point.time !== 'object') point.time = new Date(point.time);

--- a/lib/output-influx.js
+++ b/lib/output-influx.js
@@ -39,7 +39,7 @@ InfluxOutput.prototype.toString = function toString()
 
 InfluxOutput.prototype._write = function _write(event, encoding, callback)
 {
-	var point = _.pick(event, function(v) { return !_.isObject(v) && !_.isArray(v); });
+	var point = _.pick(event, ['name', 'value', 'time']);
 	if (event.time)
 		point.time = event.time;
 	if (point.time && typeof point.time !== 'object') point.time = new Date(point.time);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bole": "~2.0.0",
     "influx": "~3.4.0",
     "json-stream": "~1.0.0",
-    "lodash": "~3.10.0",
+    "lodash": "~4.3.0",
     "numbat-influx": "~0.1.1",
     "replify": "~1.2.0",
     "request": "~2.67.0",

--- a/test/test-02-influx.js
+++ b/test/test-02-influx.js
@@ -128,7 +128,7 @@ describe('influx client', function()
 		var output = new Influx(mockopts);
 		output.client = new MockClient();
 
-		output.write({ name: 'test', value: 4, obj: {}, fn: function(){} }, function()
+		output.write({ name: 'test', value: 4, obj: {}, fn: function(){}, arr : [] }, function()
 		{
 			output.client.must.have.property('name');
 			output.client.name.must.equal('test');
@@ -137,6 +137,7 @@ describe('influx client', function()
 			output.client.point.value.must.equal(4);
 			output.client.point.must.not.have.property('obj');
 			output.client.point.must.not.have.property('fn');
+			output.client.point.must.not.have.property('arr');
 			done();
 		});
 	});

--- a/test/test-02-influx.js
+++ b/test/test-02-influx.js
@@ -128,7 +128,7 @@ describe('influx client', function()
 		var output = new Influx(mockopts);
 		output.client = new MockClient();
 
-		output.write({ name: 'test', value: 4, obj: {}, fn: function(){}, arr : [] }, function()
+		output.write({ name: 'test', value: 4, obj: {}, fn: function() {}, arr : [] }, function()
 		{
 			output.client.must.have.property('name');
 			output.client.name.must.equal('test');

--- a/test/test-02-influx.js
+++ b/test/test-02-influx.js
@@ -128,13 +128,15 @@ describe('influx client', function()
 		var output = new Influx(mockopts);
 		output.client = new MockClient();
 
-		output.write({ name: 'test', value: 4 }, function()
+		output.write({ name: 'test', value: 4, obj: {}, fn: function(){} }, function()
 		{
 			output.client.must.have.property('name');
 			output.client.name.must.equal('test');
 			output.client.must.have.property('point');
 			output.client.point.name.must.equal('test');
 			output.client.point.value.must.equal(4);
+			output.client.point.must.not.have.property('obj');
+			output.client.point.must.not.have.property('fn');
 			done();
 		});
 	});


### PR DESCRIPTION
This fixes #43.

Seems like the lodash `_.pick()` method have changed between [3.10.x](https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_pickobject-predicate-thisarg) and [4.3.x](https://lodash.com/docs#pick). 

This only makes the tests pass by picking the object properties needed to make the test pass. The old code was more verbose. Are there more properties that should be picked here?