### PR TITLE
fix: clean up influxdb data on the way out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
     - '4'
     - '6'
     - '7'
-script:
-    - npm run travis
+script: npm run travis
 sudo: false
 after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ When using the websocket option, the following additional parameters can be prov
 
 ## Outputs
 
-* `influx`: [InfluxDB 0.8](http://influxdb.org/): a time-series database that can drive interesting dashboards.
-* `influx9`: InfluxDB 0.9, client provided by the [numbat-influx](https://github.com/numbat-metrics/numbat-influx) module
+* `influx`: InfluxDB 0.9, client provided by the [numbat-influx](https://github.com/numbat-metrics/numbat-influx) module
 * `logfile`: a json-formatted logfile (using [bole](https://github.com/rvagg/bole)); in case you want logging for any reason
 * `prettylog`: a pretty-formatted colorized console log
 * `analyzer`: [numbat-analyzer](https://github.com/numbat-metrics/numbat-analyzer), the incomplete alerting & monitoring component of the numbat-powered metrics system.

--- a/lib/output-influx.js
+++ b/lib/output-influx.js
@@ -5,7 +5,7 @@ var
 	Influx = require('influx'),
 	stream = require('stream'),
 	util   = require('util')
-;
+	;
 
 var InfluxOutput = module.exports = function InfluxOutput(opts)
 {
@@ -17,11 +17,22 @@ var InfluxOutput = module.exports = function InfluxOutput(opts)
 
 	stream.Writable.call(this, { objectMode: true });
 	if (!opts.requestTimeout) opts.requestTimeout = 65000; // in ms
+	if (!opts.batchTimeout) opts.batchTimeout = 30000; // in ms
 
 	this.options = opts;
-	this.client = Influx(opts);
-	this.log = bole('influx');
-	this.log.info('influx output configured');
+	this.client = new Influx.InfluxDB(opts);
+
+	this.batch = {};
+	this.batchLength = 0;
+	// Default to 1 to be backwards-compatible.
+	this.batchSize = opts.batchSize || 1;
+
+	this.batchTimeout = opts.batchTimeout;
+	this.nextBatchTime = Date.now() + opts.batchTimeout;
+	this.resetTimer();
+
+	this.log = bole('influx-9');
+	this.log.info('influx output configured for ' + opts.database);
 };
 util.inherits(InfluxOutput, stream.Writable);
 
@@ -29,6 +40,8 @@ InfluxOutput.prototype.client    = null;
 InfluxOutput.prototype.errcount  = 0;
 InfluxOutput.prototype.lasterror = 0;
 InfluxOutput.prototype.THROTTLE  = 300000; // 5 minutes
+InfluxOutput.prototype.batchTimeout = 0;
+InfluxOutput.prototype.nextBatchTime = 0;
 
 InfluxOutput.prototype.toString = function toString()
 {
@@ -37,15 +50,26 @@ InfluxOutput.prototype.toString = function toString()
 		' ]';
 };
 
-InfluxOutput.prototype._write = function _write(event, encoding, callback)
+InfluxOutput.prototype.resetTimer = function resetTimer()
 {
-	var point = _.pickBy(event, function(v) { return !_.isObject(v) && !_.isArray(v); });
-	if (event.time)
-		point.time = event.time;
-	if (point.time && typeof point.time !== 'object') point.time = new Date(point.time);
-
 	var self = this;
-	self.client.writePoint(event.name, point, function(err)
+	if (this.timer)
+		clearTimeout(this.timer);
+	this.timer = setTimeout(function() { self.writeBatch(); }, self.batchTimeout);
+	this.nextBatchTime = Date.now() + self.batchTimeout;
+};
+
+InfluxOutput.prototype.writeBatch = function writeBatch()
+{
+	var self = this;
+	if (!self.batch || !self.batchLength) return;
+
+	var batch = self.batch;
+	self.batch = {};
+	self.batchLength = 0;
+	self.resetTimer();
+
+	self.client.writeSeries(batch, function(err)
 	{
 		if (err)
 		{
@@ -57,8 +81,7 @@ InfluxOutput.prototype._write = function _write(event, encoding, callback)
 					self.log.error(self.errcount + ' error(s) writing points to influx suppressed');
 				else
 				{
-					self.log.error('failure writing a point to influx:');
-					self.log.error(event.name, point);
+					self.log.error('failure writing batch to influx:');
 					self.log.error(err);
 				}
 				self.errcount = 0;
@@ -67,6 +90,46 @@ InfluxOutput.prototype._write = function _write(event, encoding, callback)
 				self.errcount++;
 		}
 	});
+};
+
+InfluxOutput.sanitizeTag = function sanitizeTag(input)
+{
+	return input.replace(/[`~!@#$%^&*()|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '_').replace(/\s+/gi, '_');
+};
+
+InfluxOutput.prototype._write = function _write(event, encoding, callback)
+{
+	if (!event.name) return callback();
+	if (event.name.match(/heartbeat/)) return callback();
+	if (_.isUndefined(event.value)) return callback();
+	var point = { value: event.value };
+	var name = event.name;
+
+	var tags = {};
+	_.each(event, function(v, k)
+	{
+		if (k === 'time') return;
+		if (k === 'value') return;
+		if (k === 'name') return;
+		if (!_.isObject(v) && !_.isArray(v) && !_.isUndefined(v) && !_.isNull(v))
+			tags[InfluxOutput.sanitizeTag(k)] = v;
+	});
+
+	if (event.time)
+		point.time = event.time;
+	if (point.time && typeof point.time !== 'object')
+		point.time = new Date(point.time);
+
+	++this.batchLength;
+	if (!this.batch[name])
+		this.batch[name] = [[point, tags]];
+	else
+		this.batch[name].push([point, tags]);
+
+	if (this.batchLength >= this.batchSize || Date.now() > this.nextBatchTime)
+	{
+		this.writeBatch();
+	}
 
 	// we are firing & forgetting.
 	callback();

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -7,7 +7,6 @@ var
 	bole      = require('bole'),
 	Graphite  = require('./output-graphite'),
 	Influx    = require('./output-influx'),
-	Influx9   = require('numbat-influx'),
 	Log       = require('./output-logfile'),
 	PrettyLog = require('./output-prettylog'),
 	stream    = require('stream'),
@@ -32,8 +31,6 @@ var Sink = module.exports = function Sink(outputs)
 
 		case 'influx9':
 		case 'influxdb9':
-			return new Influx9(opts);
-
 		case 'influx':
 		case 'influxdb':
 			return new Influx(opts);

--- a/package.json
+++ b/package.json
@@ -12,10 +12,9 @@
   "dependencies": {
     "bistre": "~1.0.1",
     "bole": "~3.0.1",
-    "influx": "~5.0.4",
+    "influx": "~4.2.0",
     "json-stream": "~1.0.0",
     "lodash": "~4.17.2",
-    "numbat-influx": "~0.1.1",
     "replify": "~1.2.0",
     "request": "~2.79.0",
     "ws": "~1.1.1"

--- a/test/configs/socket-influx9.js
+++ b/test/configs/socket-influx9.js
@@ -7,20 +7,21 @@ module.exports =
 	},
 	listen:
 	{
-		udp:  true,
+		udp:  false,
 		port: 4677
 	},
 	outputs:
 	[
 		{ type: 'prettylog', name: 'numbat-1', pipe: true },
-		{ type: 'influx9',
+		{ type: 'influx',
 			hosts:
 			[
 				{ host: 'localhost',  port: 8086 },
 			],
 			username: 'test',
 			password: 'test',
-			database: 'test'
+			database: 'test',
+			batchSize: 2,
 		},
 	]
 };


### PR DESCRIPTION
This should prevent the collector from poisoning batches quite as often as it does right now. We achieve this by cleaning up tag names on their way through, and by throwing out tags with null/undefined data. Added tests to verify that we're sanitizing.

While I was meddling, pulled in the client formerly called influx9 into the collector code, and threw out the client for versions of influxdb < 0.9.  Pinned influx@4.2.2 for the client library because we're using influxdb 0.13 in production right now. Eventually we'll want to upgrade to influxdb 1.1.1 and version 5 of the client, but not today.